### PR TITLE
Fix Memory Leak

### DIFF
--- a/Source/sup.cpp
+++ b/Source/sup.cpp
@@ -2448,6 +2448,18 @@ NTSTATUS supVerifyFileSignature(
 
     } while (FALSE);
 
+    if (hWVTStateData) {
+        WINTRUST_DATA wintrustData;
+    
+        RtlSecureZeroMemory(&wintrustData, sizeof(wintrustData));
+        wintrustData.cbStruct = sizeof(wintrustData);
+        wintrustData.dwStateAction = WTD_STATEACTION_CLOSE;
+        wintrustData.hWVTStateData = hWVTStateData;
+        GUID guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+        WinVerifyTrust(NULL, &guid, &wintrustData);
+        hWVTStateData = NULL;
+    }
+
     if (hFile) NtClose(hFile);
     if (usFileName.Buffer != NULL)
         RtlFreeUnicodeString(&usFileName);

--- a/Source/sup.cpp
+++ b/Source/sup.cpp
@@ -2455,8 +2455,8 @@ NTSTATUS supVerifyFileSignature(
         wintrustData.cbStruct = sizeof(wintrustData);
         wintrustData.dwStateAction = WTD_STATEACTION_CLOSE;
         wintrustData.hWVTStateData = hWVTStateData;
-        GUID guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
-        WinVerifyTrust(NULL, &guid, &wintrustData);
+        GUID guidAction = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+        WinVerifyTrust(NULL, &guidAction, &wintrustData);
         hWVTStateData = NULL;
     }
 


### PR DESCRIPTION
The memory leak arises because supVerifyFileSignature requests WinTrust state (hWVTStateData) via WTGetSignatureInfo but never closes this handle before returning. Each call therefore leaves WinTrust buffers allocated, accumulating ~20 MB per run.